### PR TITLE
Improve the validation of Monero addresses.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
 		</dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.63</version>
+        </dependency>
 	</dependencies>
 	<scm>
 	  <connection>scm:git:git://github.com/monero-ecosystem/monero-java.git</connection>

--- a/src/main/java/common/utils/GenUtils.java
+++ b/src/main/java/common/utils/GenUtils.java
@@ -8,6 +8,8 @@ import java.util.List;
  */
 public class GenUtils {
   
+  public static final int[] EMPTY_INT_ARRAY = new int[0];
+  
   /**
    * Converts a templated array to a list.
    * 
@@ -43,5 +45,31 @@ public class GenUtils {
     String str = "";
     for (int i = 0; i < length; i++) str += "  "; // two spaces
     return str;
+  }
+  
+  /**
+   * Produces a new array containing the elements between
+   * the start and end indices.
+   * <p>
+   * Code from <a href="https://commons.apache.org/proper/commons-lang/">Apache Commons Lang</a>.
+   */
+  public static int[] subarray(final int[] array, int startIndexInclusive, int endIndexExclusive) {
+    if (array == null) {
+        return null;
+    }
+    if (startIndexInclusive < 0) {
+        startIndexInclusive = 0;
+    }
+    if (endIndexExclusive > array.length) {
+        endIndexExclusive = array.length;
+    }
+    final int newSize = endIndexExclusive - startIndexInclusive;
+    if (newSize <= 0) {
+        return EMPTY_INT_ARRAY;
+    }
+
+    final int[] subarray = new int[newSize];
+    System.arraycopy(array, startIndexInclusive, subarray, 0, newSize);
+    return subarray;
   }
 }

--- a/src/main/java/common/utils/JsonUtils.java
+++ b/src/main/java/common/utils/JsonUtils.java
@@ -93,6 +93,7 @@ public class JsonUtils {
    * @param type is the parameterized type to deserialize to (e.g. new TypeReference<Map<String, Object>>(){})
    * @return T is the object deserialized from JSON to the given parameterized type
    */
+  @SuppressWarnings("unchecked")
   public static <T> T deserialize(ObjectMapper mapper, String json, TypeReference<T> type) {
     try {
       return (T) mapper.readValue(json, type);

--- a/src/main/java/monero/daemon/model/MoneroNetworkType.java
+++ b/src/main/java/monero/daemon/model/MoneroNetworkType.java
@@ -4,7 +4,23 @@ package monero.daemon.model;
  * Enumerates daemon networks.
  */
 public enum MoneroNetworkType {
-  MAINNET,
-  TESTNET,
-  STAGENET
+  MAINNET(18, 19),
+  TESTNET(53, 54),
+  STAGENET(53, 54);
+
+  private final int codeForRegularAddress;
+  private final int codeForIntegratedAddress;
+
+  private MoneroNetworkType(int codeForRegularAddress, int codeForIntegratedAddress) {
+    this.codeForRegularAddress = codeForRegularAddress;
+    this.codeForIntegratedAddress = codeForIntegratedAddress;
+  }
+
+  public int getCodeForRegularAddress() {
+    return this.codeForRegularAddress;
+  }
+
+  public int getCodeForIntegratedAddress() {
+    return this.codeForIntegratedAddress;
+  }
 }

--- a/src/main/java/monero/utils/MoneroUtils.java
+++ b/src/main/java/monero/utils/MoneroUtils.java
@@ -140,7 +140,7 @@ public class MoneroUtils {
 
     String decodedAddrStr = decodeToHexString(address);
     assertTrue(isValidAddressNetwork(decodedAddrStr, isIntegratedAddress, moneroNetworkType));
-    assertTrue(isValidAddressHash(decodedAddrStr, isIntegratedAddress));
+    assertTrue(isValidAddressHash(decodedAddrStr));
   }
   
   protected static boolean isValidAddressNetwork(String decodedAddrStr,
@@ -168,7 +168,7 @@ public class MoneroUtils {
     return match;
   }
     
-  protected static boolean isValidAddressHash(String decodedAddrStr, boolean isIntegratedAddress) {
+  protected static boolean isValidAddressHash(String decodedAddrStr) {
     String checksumCheck = decodedAddrStr.substring(decodedAddrStr.length() - 8);
     String withoutChecksumStr = decodedAddrStr.substring(0, decodedAddrStr.length() - 8);
     byte[] withoutChecksumBytes = hexToBin(withoutChecksumStr);

--- a/src/main/java/monero/utils/MoneroUtils.java
+++ b/src/main/java/monero/utils/MoneroUtils.java
@@ -4,14 +4,23 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.apache.commons.codec.binary.Hex;
+import org.bouncycastle.jcajce.provider.digest.Keccak;
 
 import common.utils.GenUtils;
+import monero.daemon.model.MoneroNetworkType;
 import monero.daemon.model.MoneroTx;
 import monero.wallet.model.MoneroTxWallet;
 
@@ -25,14 +34,37 @@ public class MoneroUtils {
 
   private static final int NUM_MNEMONIC_WORDS = 25;
   private static final int VIEW_KEY_LENGTH = 64;
-  private static final char[] ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz".toCharArray();
+  private static final String ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
   private static final List<Character> CHARS = new ArrayList<Character>();
   static {
-    for (char c : ALPHABET) {
+    for (char c : ALPHABET.toCharArray()) {
       CHARS.add(c);
     }
   }
+  protected final static BigDecimal ALPHABET_SIZE = new BigDecimal(ALPHABET.length());
+  protected final static Map<Integer, Integer> ENCODED_BLOCK_SIZE = new HashMap<Integer, Integer>();
+  static {
+      ENCODED_BLOCK_SIZE.put(0, 0);
+      ENCODED_BLOCK_SIZE.put(2, 1);
+      ENCODED_BLOCK_SIZE.put(3, 2);
+      ENCODED_BLOCK_SIZE.put(5, 3);
+      ENCODED_BLOCK_SIZE.put(6, 4);
+      ENCODED_BLOCK_SIZE.put(7, 5);
+      ENCODED_BLOCK_SIZE.put(9, 6);
+      ENCODED_BLOCK_SIZE.put(10, 7);
+      ENCODED_BLOCK_SIZE.put(11, 8);
+  };
+  protected final static int FULL_BLOCK_SIZE = 8;
+  protected final static int FULL_ENCODED_BLOCK_SIZE = 11;
+  protected final static BigDecimal UINT64_MAX = new BigDecimal(Math.pow(2, 64));
+  protected final static int[] EMPTY_INT_ARRAY = new int[0];
   
+  protected final static Pattern MONERO_REGULAR_ADDRESS_PATTERN =
+      Pattern.compile("^[" + ALPHABET + "]{95}$");
+
+  protected final static Pattern MONERO_INTEGRATED_ADDRESS_PATTERN =
+        Pattern.compile("^[" + ALPHABET + "]{106}$");
+
   /**
    * Validates a wallet seed.
    * 
@@ -82,10 +114,71 @@ public class MoneroUtils {
     assertEquals(64, publicSpendKey.length());
   }
   
-  // TODO: improve validation
+  /**
+   * Validate an address but ignore the type of network.
+   */
   public static void validateAddress(String address) {
+    validateAddress(address, null);
+  }
+  
+  /**
+   * @param moneroNetworkType if <code>null</code> the validation will
+   * ignore the type of network.
+   */
+  public static void validateAddress(String address, MoneroNetworkType moneroNetworkType) {
     assertNotNull(address);
-    assertFalse(address.isEmpty());
+    assertFalse(address.isEmpty()); 
+    
+    boolean isIntegratedAddress = false;
+    if (!MONERO_REGULAR_ADDRESS_PATTERN.matcher(address).matches()) {
+        if (MONERO_INTEGRATED_ADDRESS_PATTERN.matcher(address).matches()) {
+            isIntegratedAddress = true;
+        } else {
+            fail("Invalid regEx pattern for the address");
+        }
+    }
+
+    String decodedAddrStr = decodeToHexString(address);
+    assertTrue(isValidAddressNetwork(decodedAddrStr, isIntegratedAddress, moneroNetworkType));
+    assertTrue(isValidAddressHash(decodedAddrStr, isIntegratedAddress));
+  }
+  
+  protected static boolean isValidAddressNetwork(String decodedAddrStr,
+                                                 boolean isIntegratedAddress,
+                                                 MoneroNetworkType moneroNetworkType) {
+
+    int networkType = Integer.parseInt(decodedAddrStr.substring(0, 2), 16);
+    
+    boolean match = false;
+    if (moneroNetworkType == null || moneroNetworkType == MoneroNetworkType.MAINNET) {
+      match = isIntegratedAddress ? MoneroNetworkType.MAINNET.getCodeForIntegratedAddress() == networkType : 
+                                    MoneroNetworkType.MAINNET.getCodeForRegularAddress() == networkType;
+    }
+    
+    if (match == false && (moneroNetworkType == null || moneroNetworkType == MoneroNetworkType.TESTNET)) {
+      match = isIntegratedAddress ? MoneroNetworkType.TESTNET.getCodeForIntegratedAddress() == networkType : 
+                                    MoneroNetworkType.TESTNET.getCodeForRegularAddress() == networkType;
+    }
+    
+    if (match == false && (moneroNetworkType == null || moneroNetworkType == MoneroNetworkType.STAGENET)) {
+      match = isIntegratedAddress ? MoneroNetworkType.STAGENET.getCodeForIntegratedAddress() == networkType : 
+                                    MoneroNetworkType.STAGENET.getCodeForRegularAddress() == networkType;
+    }
+    
+    return match;
+  }
+    
+  protected static boolean isValidAddressHash(String decodedAddrStr, boolean isIntegratedAddress) {
+    String checksumCheck = decodedAddrStr.substring(decodedAddrStr.length() - 8);
+    String withoutChecksumStr = decodedAddrStr.substring(0, decodedAddrStr.length() - 8);
+    byte[] withoutChecksumBytes = hexToBin(withoutChecksumStr);
+    
+    Keccak.Digest256 digest256 = new Keccak.Digest256();
+    byte[] hashbytes = digest256.digest(withoutChecksumBytes);
+    String encodedStr = Hex.encodeHexString(hashbytes);
+    
+    String hashChecksum = encodedStr.substring(0, 8);
+    return hashChecksum != null && hashChecksum.equals(checksumCheck);
   }
   
   // TODO: improve validation
@@ -309,4 +402,109 @@ public class MoneroUtils {
     }
     txs.add(tx);
   }
+  
+  private static String decodeToHexString(String address) {
+    int[] bin = new int[address.length()];
+    for (int i = 0; i < address.length(); i++) {
+      bin[i] = address.codePointAt(i);
+    }
+
+    int fullBlockCount = (int)Math.floor(bin.length / FULL_ENCODED_BLOCK_SIZE);
+    int lastBlockSize = (int)bin.length % FULL_ENCODED_BLOCK_SIZE;
+    int lastBlockDecodedSize = ENCODED_BLOCK_SIZE.get(lastBlockSize);
+    if (lastBlockDecodedSize < 0) {
+      throw new IllegalArgumentException("Invalid encoded length");
+    }
+
+    int dataSize = fullBlockCount * FULL_BLOCK_SIZE + lastBlockDecodedSize;
+    int[] data = new int[dataSize];
+    for (int i = 0; i < fullBlockCount; i++) {
+      data = decodeBlock(GenUtils.subarray(bin,
+                    i * FULL_ENCODED_BLOCK_SIZE,
+                    i * FULL_ENCODED_BLOCK_SIZE + FULL_ENCODED_BLOCK_SIZE),
+                 data,
+                 i * FULL_BLOCK_SIZE);
+    }
+    if (lastBlockSize > 0) {
+      int[] subarray = GenUtils.subarray(bin,
+                    fullBlockCount * FULL_ENCODED_BLOCK_SIZE,
+                    fullBlockCount * FULL_ENCODED_BLOCK_SIZE + FULL_BLOCK_SIZE);
+
+      data = decodeBlock(subarray,
+                 data,
+                 fullBlockCount * FULL_BLOCK_SIZE);
+    }
+
+    return toHexString(data);
+  }
+
+  private static int[] decodeBlock(int[] data, int[] buf, int index) {
+
+    if (data.length < 1 || data.length > FULL_ENCODED_BLOCK_SIZE) {
+      throw new RuntimeException("Invalid block length: " + data.length);
+    }
+
+    int resSize = ENCODED_BLOCK_SIZE.get(data.length);
+    if (resSize <= 0) {
+      throw new RuntimeException("Invalid block size");
+    }
+    BigDecimal resNum = BigDecimal.ZERO;
+    BigDecimal order = BigDecimal.ONE;
+    for (int i = data.length - 1; i >= 0; i--) {
+      int digit = ALPHABET.indexOf(data[i]);
+      if (digit < 0) {
+        throw new RuntimeException("Invalid symbol");
+      }
+      BigDecimal product = order.multiply(new BigDecimal(digit)).add(resNum);
+      // if product > UINT64_MAX
+      if (product.compareTo(UINT64_MAX) > 0) {
+        throw new RuntimeException("Overflow");
+      }
+      resNum = product;
+      order = order.multiply(ALPHABET_SIZE);
+    }
+    if (resSize < FULL_BLOCK_SIZE && (new BigDecimal(2).pow(8 * resSize).compareTo(resNum) <= 0)) {
+      throw new RuntimeException("Overflow 2");
+    }
+
+    int[] tmpBuf = uint64To8be(resNum, resSize);
+    for (int j = 0; j < tmpBuf.length; j++) {
+      buf[j + index] = tmpBuf[j];
+    }
+
+    return buf;
+  }
+
+  private static int[] uint64To8be(BigDecimal num, int size) {
+    int[] res = new int[size];
+    if (size < 1 || size > 8) {
+      throw new RuntimeException("Invalid input length");
+    }
+    BigDecimal twopow8 = new BigDecimal(2).pow(8);
+    for (int i = size - 1; i >= 0; i--) {
+      res[i] = num.remainder(twopow8).intValue();
+      num = num.divide(twopow8);
+    }
+    return res;
+  }
+
+  private static byte[] hexToBin(String hexStr) {
+    if (hexStr == null || hexStr.length() % 2 != 0) {
+      return null;
+    }
+    byte[] res = new byte[hexStr.length() / 2];
+    for (int i = 0; i < hexStr.length() / 2; ++i) {
+      res[i] = (byte)Integer.parseInt(hexStr.substring(i * 2, i * 2 + 2), 16);
+    }
+    return res;
+  }
+
+  private static String toHexString(int[] data) {
+    StringBuilder builder = new StringBuilder();
+    for (int i : data) {
+      builder.append(String.format("%02x", i));
+    }
+    return builder.toString();
+  }
+  
 }

--- a/src/test/java/test/TestMoneroWalletGeneric.java
+++ b/src/test/java/test/TestMoneroWalletGeneric.java
@@ -1,0 +1,26 @@
+package test;
+
+import org.junit.Test;
+
+import monero.daemon.model.MoneroNetworkType;
+import monero.utils.MoneroUtils;
+
+public class TestMoneroWalletGeneric {
+
+  @Test
+  public void testAddressValidation() {
+    
+    // Regular addresses
+    MoneroUtils.validateAddress("46oTQPpoxoxQ6XGWwPqEK1YvADH8X91rFC6brLWRHokoAC5qwbYKA2e9jzQyapENw4V2w5Tz1d4LiMSuDhhFCCf77mQgLRA");
+    MoneroUtils.validateAddress("46oTQPpoxoxQ6XGWwPqEK1YvADH8X91rFC6brLWRHokoAC5qwbYKA2e9jzQyapENw4V2w5Tz1d4LiMSuDhhFCCf77mQgLRA", MoneroNetworkType.MAINNET);
+    MoneroUtils.validateAddress("47zQ5LAivg6hNCgijXSEFVLX7mke1bgM6YGLFaANDoJbgXDymcAAZvvMNt2PmMpqEe5qRy2zyfMYXdwpmdyitiFh84xnPG2");
+    MoneroUtils.validateAddress("48bWuoDG75CXMDHbmPEvUF2hm1vLDic7ZJ7hqRkL65QR9p13AQAX4eEACXNk4YP115Q4KRVZnAvmMBHrcGfv9FvKPZnH6vH");
+    MoneroUtils.validateAddress("A2be3UvzMtkJtxRYgcCbQt2y7Rp2eLVGqNTWfZeankrWimSMM4y7uMP6B9oAZaHsXTj8KFSerkSkkVRuEuEca9QM8VhxCNU");
+    MoneroUtils.validateAddress("A2be3UvzMtkJtxRYgcCbQt2y7Rp2eLVGqNTWfZeankrWimSMM4y7uMP6B9oAZaHsXTj8KFSerkSkkVRuEuEca9QM8VhxCNU", MoneroNetworkType.TESTNET);
+    
+    // Integrated addresses
+    MoneroUtils.validateAddress("4Gd4DLiXzBmbVX2FZZ3Cvu6fUaWACup1qDowprUCje1kSP4FmbftiJMSfV8kWZXNqmVwj4m52xqtgFNUudVmsmGkGvkLcCibWfVUfUFVB7");
+    MoneroUtils.validateAddress("4J5sF94AzXgFgx8LuWc9dcWkJkGkD3cL3L2AuhX6QA9jFvSxxj6QhHqHXqM2b2Go7G8RyDzEbHxYd9G26XUUbuJChipEyBz9fENMU2Ua9b");
+  }
+  
+}


### PR DESCRIPTION
This code is based on existing implementations:
- https://github.com/bigreddmachine/MoneroPy/blob/master/moneropy/base58.py
- https://github.com/ognus/wallet-address-validator/blob/master/src/monero_validator.js

More doc: 
- https://monerodocs.org/cryptography/base58/

The PR idea comes from: 
- https://monero.stackexchange.com/questions/11626/monero-address-validation-using-java

----------

Please note that I'm not an expert at this level of coding (dealing with byte[], encryption, etc.). I tried my best to convert the code from implementations in other languages to Java. But maybe I use `int[]` at some places where `byte[]` should be used and/or the opposite!

Feel free to improve the code!

Also:
- I wasn't 100% sure where to put the code in the project.
- I'm not sure about the rules for the STAGENET network. I don't think I've seen any tests for it anywhere... This PR currently uses the same code as the TESTNET network.
- I had to add `Bouncy Castle` as a dependency for `Keccak 256` digests.
- I only ran the new tests (for this PR), since I currently do not have any Monero deamon running. Maybe I broke some other tests. Please check!
